### PR TITLE
feat/v2v-daemon

### DIFF
--- a/selfdrive/v2v/mock_v2v_publisher.py
+++ b/selfdrive/v2v/mock_v2v_publisher.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import time
+import math
+import cereal.messaging as messaging
+from openpilot.common.realtime import Ratekeeper
+
+def mock_publisher():
+    pm = messaging.PubMaster(['carState'])
+    rk = Ratekeeper(10.0) # Publish at 10Hz, same as the real server
+
+    # Create a fake data message
+    v2v_dat = messaging.new_message('v2vData')
+    counter = 0
+
+    print("Starting mock V2V publisher...")
+    while True:
+        # Create some fake, dynamic data
+        v2v_dat.v2vData.vLead = 20.0 + 5.0 * math.sin(counter * 0.1) # Speed oscillates
+        v2v_dat.v2vData.aLead = 0.5 * math.cos(counter * 0.1)      # Acceleration oscillates
+
+        # Publish the message
+        pm.send('v2vData', v2v_dat)
+        print(f"Published mock data: vLead={v2v_dat.v2vData.vLead:.2f}, aLead={v2v_dat.v2vData.aLead:.2f}")
+
+        counter += 1
+        rk.keep_time()
+
+if __name__ == "__main__":
+    mock_publisher()

--- a/selfdrive/v2v/v2vd.py
+++ b/selfdrive/v2v/v2vd.py
@@ -2,13 +2,51 @@
 import time
 from openpilot.common.params import Params
 
+import socket
+import cereal.messaging as messaging
+from cereal.services import SERVICE_LIST
+
+def server_logic(host='0.0.0.0', port=8888):
+  sm = messaging.SubMaster(['carState'])
+  # Assumes V2VData is defined in cereal/log.capnp
+  v2v_dat = messaging.new_message('v2vData')
+
+  with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    s.bind((host, port))
+    s.listen()
+    print(f"Server listening on {host}:{port}")
+    conn, addr = s.accept()
+    with conn:
+      print(f"Connected by {addr}")
+      while True:
+        sm.update()
+        if sm.updated['carState']:
+          # 1. Get lead vehicle speed and acceleration
+          v_ego = sm['carState'].vEgo
+          a_ego = sm['carState'].aEgo
+
+          # 2. Pack into V2VData message
+          v2v_dat.v2vData.vLead = v_ego
+          v2v_dat.v2vData.aLead = a_ego
+
+          # 3. Serialize and send over TCP
+          try:
+            conn.sendall(v2v_dat.to_bytes())
+          except (BrokenPipeError, ConnectionResetError):
+            print("Client disconnected. Waiting for new connection.")
+            conn, addr = s.accept() # Wait for a new client
+            print(f"Reconnected by {addr}")
+
+        # Run at 10Hz
+        time.sleep(0.1)
+
 def main():
     params = Params()
     role = params.get("V2VRole", encoding='utf-8') # V2VRole should be 'host' or 'client'
 
     if role == "host":
-        # server_logic()
-        print("Starting in HOST mode.")
+        server_logic()
+        # print("Starting in HOST mode.")
     elif role == "client":
       # client_logic()
         print("Starting in CLIENT mode.")

--- a/selfdrive/v2v/v2vd.py
+++ b/selfdrive/v2v/v2vd.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import time
+
+def main():
+  # Your daemon's logic will go here
+  while True:
+    print("v2vd running...")
+    time.sleep(1)
+
+if __name__ == "__main__":
+  main()

--- a/selfdrive/v2v/v2vd.py
+++ b/selfdrive/v2v/v2vd.py
@@ -1,11 +1,24 @@
 #!/usr/bin/env python3
 import time
+from openpilot.common.params import Params
 
 def main():
-  # Your daemon's logic will go here
-  while True:
-    print("v2vd running...")
-    time.sleep(1)
+    params = Params()
+    role = params.get("V2VRole", encoding='utf-8') # V2VRole should be 'host' or 'client'
+
+    if role == "host":
+        # server_logic()
+        print("Starting in HOST mode.")
+    elif role == "client":
+      # client_logic()
+        print("Starting in CLIENT mode.")
+    else:
+        print(f"Invalid V2VRole: '{role}'. Exiting.")
+        return
+
+    while True:
+        # The respective logic function will handle the loop
+        time.sleep(1)
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/system/manager/process_config.py
+++ b/system/manager/process_config.py
@@ -5,7 +5,7 @@ import platform
 from cereal import car
 from openpilot.common.params import Params
 from openpilot.system.hardware import PC, TICI
-from openpilot.system.manager.process import PythonProcess, NativeProcess, DaemonProcess
+from openpilot.system.manager.process import Process, PythonProcess, NativeProcess, DaemonProcess
 
 WEBCAM = os.getenv("USE_WEBCAM") is not None
 
@@ -107,11 +107,14 @@ procs = [
   PythonProcess("uploader", "system.loggerd.uploader", always_run),
   PythonProcess("statsd", "system.statsd", always_run),
 
+  # V2V process
+  PythonProcess("v2vd", "selfdrive.v2v.v2vd", only_onroad),
+
   # debug procs
   NativeProcess("bridge", "cereal/messaging", ["./bridge"], notcar),
   PythonProcess("webrtcd", "system.webrtc.webrtcd", notcar),
   PythonProcess("webjoystick", "tools.bodyteleop.web", notcar),
-  PythonProcess("joystick", "tools.joystick.joystick_control", and_(joystick, iscar)),
+  PythonProcess("joystick", "tools.joystick.joystick_control", and_(joystick, iscar))
 ]
 
 managed_processes = {p.name: p for p in procs}


### PR DESCRIPTION
## Description

This PR introduces the foundational framework for a new Vehicle-to-Vehicle (V2V) communication daemon, `v2vd`. The goal of this daemon is to enable real-time data sharing between a lead vehicle (host) and an ego vehicle (client).

This initial implementation includes the following completed steps:

1.  **Feature Branch Creation:** Established the `feat/v2v-daemon` branch to isolate development.
2.  **Daemon Scaffolding:** Created the necessary directory and file for the new process at `selfdrive/v2v/daemon.py`.
3.  **Process Registration:** Successfully registered `v2vd` as a managed process in `openpilot/system/manager/process_config.py`, allowing it to be managed by `managerd`.
4.  **Role Selection Logic:** Implemented logic within the daemon to read a persistent parameter (`V2VRole`) to determine if the device should operate in "host" or "client" mode.
5.  **Server Mode Implementation:** Built out the "host" mode logic, which subscribes to the `carState` message bus to get the lead vehicle's speed and acceleration.
6.  **Data Serialization:** Implemented the packaging of speed and acceleration data into the `V2VData` Cap'n Proto message structure.
7.  **Network Broadcasting:** Established a TCP socket server that serializes and broadcasts the `V2VData` message to a connected client.

## Verification

The functionality of the new `v2vd` daemon was verified through the following steps:

1.  The `V2VRole` parameter was set to `"host"` on the device.
2.  The device was rebooted, and `managerd` correctly launched the `v2vd` process as expected.
3.  On a separate computer on the same network, a simple TCP client was used to connect to the openpilot device's IP address on port 8888.
4.  The client successfully received a continuous stream of serialized `V2VData` messages, confirming that the server logic, `cereal` message handling, and networking code are all functioning correctly.